### PR TITLE
use newer ubuntu, cvlc alias, remove double slash, and use correct boundary without --

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,25 @@
-FROM ubuntu:18.04
-RUN apt-get update; apt-get install --no-install-recommends -y vlc-bin vlc-plugin-base; apt-get clean; apt-get autoclean
-RUN useradd -ms /bin/bash streamer
-WORKDIR /home/streamer
-COPY rtsp-to-mjpeg.sh /home/streamer/
-USER streamer
-ENTRYPOINT [ "/home/streamer/rtsp-to-mjpeg.sh" ]
+FROM alpine:latest
+
+ARG UID="1000"
+ARG GID="1000"
+
+RUN apk update && \
+    apk add wget && \
+    apk add vlc && \
+    rm -rf /var/cache/apk/* && \
+    mkdir -p /opt/vlc-media && \
+    addgroup --g "${GID}" -S vlc && \
+    adduser -h /opt/vlc-media -s /bin/sh -u "${UID}" -G vlc -S vlc && \
+    cd /opt/vlc-media && \
+    chown vlc:vlc -R /opt/vlc-media
+
+WORKDIR /opt/vlc-media
+COPY rtsp-to-mjpeg.sh /opt/vlc-media
 EXPOSE 8080
+EXPOSE 554
+EXPOSE 8554
+
+USER "vlc"
+WORKDIR /opt/vlc-media
+
+ENTRYPOINT [ "/opt/vlc-media/rtsp-to-mjpeg.sh" ]

--- a/rtsp-to-mjpeg.sh
+++ b/rtsp-to-mjpeg.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/bin/vlc --intf dummy rtsp://$CAMERAUSER:$CAMERAPASSWORD@$CAMERAIP:$CAMERAPORT//$CAMERASTREAM --sout '#transcode{vcodec=MJPG,venc=ffmpeg{strict=1}}:standard{access=http{mime=multipart/x-mixed-replace;boundary=--7b3cc56e5f51db803f790dad720ed50a},mux=mpjpeg,dst=:8080/}'
+/usr/bin/cvlc rtsp://$CAMERAUSER:$CAMERAPASSWORD@$CAMERAIP:$CAMERAPORT/$CAMERASTREAM --sout '#transcode{vcodec=MJPG,venc=ffmpeg{strict=1}}:standard{access=http{mime=multipart/x-mixed-replace; boundary=myboundary},mux=mpjpeg,dst=:8080/}'


### PR DESCRIPTION
this repo has been non-functional as of late, likely due to a vlc update (issue seen here: https://github.com/div-opn/rtsp-to-mjpeg/issues/2 - though the dbus issue wasn't actually the problem)

this PR updates the dockerfile to use alpine:latest, and also cleans up some other things i had problems with:
* // before CAMERASTREAM in script
* boundary shouldn't contain `--`
* uses cvlc alias instead of initfs --dummy (not needed, but cleaner)